### PR TITLE
Added missing fan accessory

### DIFF
--- a/HomeKitBridge/accessories/fan.php
+++ b/HomeKitBridge/accessories/fan.php
@@ -100,7 +100,7 @@ class HAPAccessoryConfigurationFan
     {
         return [
             'de' => [
-                'Fan'			=> 'Lüfter',
+                'Fan'                   => 'Lüfter',
                 'VariableID'            => 'VariablenID',
                 'Variable missing'      => 'Variable fehlt',
                 'Int/Float required'    => 'Int/Float benötigt',

--- a/HomeKitBridge/accessories/fan.php
+++ b/HomeKitBridge/accessories/fan.php
@@ -100,7 +100,7 @@ class HAPAccessoryConfigurationFan
     {
         return [
             'de' => [
-                'Fan'     		=> 'Lüfter',
+                'Fan'			=> 'Lüfter',
                 'VariableID'            => 'VariablenID',
                 'Variable missing'      => 'Variable fehlt',
                 'Int/Float required'    => 'Int/Float benötigt',

--- a/HomeKitBridge/accessories/fan.php
+++ b/HomeKitBridge/accessories/fan.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+class HAPAccessoryFan extends HAPAccessoryBase
+{
+    use HelperDimDevice;
+
+    public function __construct($data)
+    {
+        parent::__construct(
+            $data,
+            [
+                new HAPServiceAccessoryInformation(),
+                new HAPServiceFan()
+            ]
+        );
+    }
+
+    public function notifyCharacteristicOn()
+    {
+        return [
+            $this->data['VariableID']
+        ];
+    }
+
+    public function readCharacteristicOn()
+    {
+        return self::getDimValue($this->data['VariableID']) > 0;
+    }
+
+    public function writeCharacteristicOn($value)
+    {
+        //Only switch the device on, if it isn't on.
+        //This should fix the problem that Apple sends on before dimming
+        if ($value && $this->readCharacteristicOn()) {
+            return;
+        }
+
+        if ($value) {
+            self::dimDevice($this->data['VariableID'], 100);
+        } else {
+            self::dimDevice($this->data['VariableID'], 0);
+        }
+    }
+
+    public function notifyCharacteristicRotationSpeed()
+    {
+        return [
+            $this->data['VariableID']
+        ];
+    }
+
+    public function readCharacteristicRotationSpeed()
+    {
+        return self::getDimValue($this->data['VariableID']);
+    }
+
+    public function writeCharacteristicRotationSpeed($value)
+    {
+        self::dimDevice($this->data['VariableID'], $value);
+    }
+}
+
+class HAPAccessoryConfigurationFan
+{
+    use HelperDimDevice;
+
+    public static function getPosition()
+    {
+        return 10;
+    }
+
+    public static function getCaption()
+    {
+        return 'Fan';
+    }
+
+    public static function getColumns()
+    {
+        return [
+            [
+                'label' => 'VariableID',
+                'name'  => 'VariableID',
+                'width' => '250px',
+                'add'   => 0,
+                'edit'  => [
+                    'type' => 'SelectVariable'
+                ]
+            ]
+        ];
+    }
+
+    public static function getStatus($data)
+    {
+        return self::getDimCompatibility($data['VariableID']);
+    }
+
+    public static function getTranslations()
+    {
+        return [
+            'de' => [
+                'Fan'     		=> 'Lüfter',
+                'VariableID'            => 'VariablenID',
+                'Variable missing'      => 'Variable fehlt',
+                'Int/Float required'    => 'Int/Float benötigt',
+                'Profile required'      => 'Profil benötigt',
+                'Action required'       => 'Aktion benötigt',
+                'OK'                    => 'OK'
+            ]
+        ];
+    }
+}
+
+HomeKitManager::registerAccessory('Fan');

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Jeder Eintrag erfordert einen Namen unter welchem das Gerät bei Apple HomeKit b
 * [Fenster (Position)][fenster-position]
 * [Fenster (Hoch/Runter)][fenster-hoch-runter]
 * [Feuchtigkeitssensor][feuchtigkeitssensor]
-* [Lüfter"][luefter]
+* [Lüfter][luefter]
 * [Garagentor][garagentor]
 * [Helligkeitssensor][helligkeitssensor]
 * [Kontaktsensor][kontaktsensor]

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ Jeder Eintrag erfordert einen Namen unter welchem das Gerät bei Apple HomeKit b
 * [Fenster (Position)][fenster-position]
 * [Fenster (Hoch/Runter)][fenster-hoch-runter]
 * [Feuchtigkeitssensor][feuchtigkeitssensor]
+* [Lüfter"][luefter]
 * [Garagentor][garagentor]
 * [Helligkeitssensor][helligkeitssensor]
 * [Kontaktsensor][kontaktsensor]
@@ -150,6 +151,7 @@ In der Home-App sollten einige der eingerichteten Geräte sichtbar unter "Bevorz
 [fenster-position]: types/fenster-position.md
 [fenster-hoch-runter]: types/fenster-hoch-runter.md
 [feuchtigkeitssensor]: types/feuchtigkeitssensor.md
+[luefter]: types/luefter.md
 [garagentor]: types/garagentor.md
 [helligkeitssensor]: types/helligkeitssensor.md
 [kontaktsensor]: types/kontaktsensor.md

--- a/docs/types/luefter.md
+++ b/docs/types/luefter.md
@@ -1,0 +1,17 @@
+### Beschreibung
+
+Geräte vom Typ Lüfter (Regulierbar) beschreiben Lampen, welche gedimmt werden können.
+
+### Parameter
+
+Name       | Beschreibung
+---------- | ---------------
+Name       | Name mit dem das Gerät über HomeKit angesprochen werden kann
+Variable   | Eine schaltbare Variable vom Typ Integer oder Float, über welche der Lüfter gesteuert wird
+
+#### Mögliche Aktionen
+
+Aktion               | Beschreibung                                   | Möglicher Satz zum Aktivieren
+-------------------- | ---------------------------------------------- | -----------------------------
+An oder Aus schalten | Schaltet die Variable auf 100% oder 0%         | "Hey Siri, schalte _<Name\>_ an."
+Regulieren           | Schaltet die Variable auf den angegebenen Wert | "Hey Siri, dimme _<Name\>_ auf 40%."

--- a/docs/types/luefter.md
+++ b/docs/types/luefter.md
@@ -1,6 +1,6 @@
 ### Beschreibung
 
-Geräte vom Typ Lüfter (Regulierbar) beschreiben Lampen, welche gedimmt werden können.
+Geräte vom Typ Lüfter (Regulierbar) beschreiben Lüfter, welche reguliert werden können.
 
 ### Parameter
 

--- a/tests/HomeKitFanTest.php
+++ b/tests/HomeKitFanTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+include_once __DIR__ . '/HomeKitBaseTest.php';
+
+class HomeKitFanTest extends HomeKitBaseTest
+{
+    public function testAccessory(): void
+    {
+        $bridgeID = IPS_CreateInstance($this->bridgeModuleID);
+
+        $VariableID = IPS_CreateVariable(1 /* Integer */);
+
+        //Currently stubs do not provide default profiles
+        if (!IPS_VariableProfileExists('~Intensity.100')) {
+            IPS_CreateVariableProfile('~Intensity.100', 1 /* Integer */);
+            IPS_SetVariableProfileValues('~Intensity.100', 0, 100, 1);
+        }
+
+        IPS_SetVariableCustomProfile($VariableID, '~Intensity.100');
+        IPS_SetVariableCustomAction($VariableID, 10001); //Any valid ID will do
+
+        IPS_SetProperty($bridgeID, 'AccessoryFan', json_encode([
+            [
+                'ID'                    => 3,
+                'Name'                  => 'Test',
+                'VariableID'            => $VariableID
+            ]
+        ]));
+        IPS_ApplyChanges($bridgeID);
+
+        $bridgeInterface = IPS\InstanceManager::getInstanceInterface($bridgeID);
+
+        $base = json_decode(file_get_contents(__DIR__ . '/exports/None.json'), true);
+        $accessory = json_decode(file_get_contents(__DIR__ . '/exports/Fan.json'), true);
+
+        //Check if the generated content matches our test file
+        $this->assertEquals(array_merge($base, $accessory), $bridgeInterface->DebugAccessories());
+    }
+}

--- a/tests/exports/Fan.json
+++ b/tests/exports/Fan.json
@@ -77,15 +77,15 @@
             "value": false
           },
           {
-            "type": "8",
+            "type": "29",
             "iid": 104,
-            "format": "int",
+            "format": "float",
             "perms": [
               "pr",
               "pw",
               "ev"
             ],
-            "value": 0,
+            "value": 0.0,
             "minValue": 0,
             "maxValue": 100,
             "minStep": 1,

--- a/tests/exports/Fan.json
+++ b/tests/exports/Fan.json
@@ -1,0 +1,107 @@
+[
+  {
+    "aid": 3,
+    "services": [
+      {
+        "type": "3E",
+        "iid": 1,
+        "characteristics": [
+          {
+            "type": "14",
+            "iid": 2,
+            "format": "bool",
+            "perms": [
+              "pw"
+            ]
+          },
+          {
+            "type": "20",
+            "iid": 3,
+            "format": "string",
+            "perms": [
+              "pr"
+            ],
+            "value": "IP-Symcon Community"
+          },
+          {
+            "type": "21",
+            "iid": 4,
+            "format": "string",
+            "perms": [
+              "pr"
+            ],
+            "value": "Fan"
+          },
+          {
+            "type": "23",
+            "iid": 5,
+            "format": "string",
+            "perms": [
+              "pr"
+            ],
+            "value": "Test"
+          },
+          {
+            "type": "30",
+            "iid": 6,
+            "format": "string",
+            "perms": [
+              "pr"
+            ],
+            "value": "db699d5a"
+          },
+          {
+            "type": "52",
+            "iid": 7,
+            "format": "string",
+            "perms": [
+              "pr"
+            ],
+            "value": "5.0"
+          }
+        ]
+      },
+      {
+        "type": "40",
+        "iid": 101,
+        "characteristics": [
+          {
+            "type": "25",
+            "iid": 102,
+            "format": "bool",
+            "perms": [
+              "pr",
+              "pw",
+              "ev"
+            ],
+            "value": false
+          },
+          {
+            "type": "8",
+            "iid": 104,
+            "format": "int",
+            "perms": [
+              "pr",
+              "pw",
+              "ev"
+            ],
+            "value": 0,
+            "minValue": 0,
+            "maxValue": 100,
+            "minStep": 1,
+            "unit": "percentage"
+          },
+          {
+            "type": "23",
+            "iid": 105,
+            "format": "string",
+            "perms": [
+              "pr"
+            ],
+            "value": "Test"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
I wanted to add a fan to Homekit. However, I noticed that there was no accessory supporting this. I did see that the characteristic and service code were present, so I just simply added the accessory supporting on/off state and rotation speed.

I'm not proficient in German, so I'm not 100% confident that the documentation that I have written is correct. Please do check.